### PR TITLE
Fix SMAUGlocale linker reference

### DIFF
--- a/src/i18n.c
+++ b/src/i18n.c
@@ -50,6 +50,8 @@
 
 #include "mud.h"
 
+const char *SMAUGlocale = NULL;
+
 void fread_locale args((LOCALE_DATA * locale, FILE * fp));
 bool load_locales_file args((char * localesfile));
 


### PR DESCRIPTION
## Summary
- define the `SMAUGlocale` variable in `i18n.c`

## Testing
- `make -C src smaug-i18n.o`

------
https://chatgpt.com/codex/tasks/task_e_6845b4cc0b88832c8dfc1d6ec423b114