### PR TITLE
Fix i18n_getlocale prototype

### DIFF
--- a/src/i18n.c
+++ b/src/i18n.c
@@ -56,10 +56,10 @@ void fread_locale args((LOCALE_DATA * locale, FILE * fp));
 bool load_locales_file args((char * localesfile));
 
 /* Get server locale from env LANG */
-int
+void
 i18n_getlocale (void)
 {
-	SMAUGlocale = getenv("LANG");
+        SMAUGlocale = getenv("LANG");
 }
 
 /* Set server locale */

--- a/src/i18n.h
+++ b/src/i18n.h
@@ -77,5 +77,5 @@ struct locale_data
 const char *SMAUGlocale;
 
 int i18n_setlocale (void);
-int i18n_getlocale (void);
+void i18n_getlocale (void);
 


### PR DESCRIPTION
## Summary
- make `i18n_getlocale` return `void`
- adjust the implementation accordingly

## Testing
- `make` *(fails: intltool too old)*

------
https://chatgpt.com/codex/tasks/task_e_6845b71a9e20832c9925a4078f294e18