### PR TITLE
Fix format string vulnerability

### DIFF
--- a/src/smaug.c
+++ b/src/smaug.c
@@ -1896,7 +1896,7 @@ nanny (DESCRIPTOR_DATA * d, char *argument)
       if (chk == TRUE)
 	return;
 
-      sprintf (buf, ch->pcdata->filename);
+      snprintf(buf, sizeof(buf), "%s", ch->pcdata->filename);
       d->character->desc = NULL;
       free_char (d->character);
       d->character = NULL;


### PR DESCRIPTION
## Summary
- protect against format string issues in `nanny()`

## Testing
- `make -j$(nproc)` *(fails: multiple definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845b8e8aa10832cb5c2ad96aa8d4f8c