### PR TITLE
Add Dockerfile and server startup docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential autoconf automake libtool pkg-config intltool file \
+        git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy source
+WORKDIR /opt/smaug
+COPY . /opt/smaug
+
+# Build and install
+RUN ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install
+
+EXPOSE 4000
+
+CMD ["/bin/bash", "-c", "/usr/local/etc/init.d/smaugd start && tail -F /usr/local/var/log/smaug/smaug.log"]

--- a/README.md
+++ b/README.md
@@ -372,6 +372,32 @@ Compile and install the MUD server with the usual autotools workflow:
 ./autogen.sh && ./configure && make && make install
 ```
 
+### Running
+
+Start the daemon after installation using the provided init script:
+
+```bash
+sudo /usr/local/etc/init.d/smaugd start
+```
+
+Stop it with:
+
+```bash
+sudo /usr/local/etc/init.d/smaugd stop
+```
+
+### Quickstart with Docker
+
+You can also build and run the server in a container without installing
+anything locally:
+
+```bash
+docker build -t smaug .
+docker run -it -p 4000:4000 smaug
+```
+
+The container starts the daemon and streams its log to the console.
+
 
 ### Authors and Contributors
 


### PR DESCRIPTION
## Summary
- provide Dockerfile for a prebuilt runtime environment
- document how to start the server normally
- document how to run the server via Docker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68462da3ef1c832c9e1b84875c122725